### PR TITLE
Add base instructions for the spark-job-server image definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM java:7
+
+RUN apt-get update && apt-get install -y git --no-install-recommends
+
+ENV SCALA_VERSION 2.10.5
+ENV SCALA_MAJOR_VERSION 2.10
+ENV SCALA_HOME /usr/local/share/scala
+ENV PATH ${PATH}:${SCALA_HOME}/bin
+
+RUN mkdir -p ${SCALA_HOME}
+RUN wget -qO- http://www.scala-lang.org/files/archive/scala-${SCALA_VERSION}.tgz \
+  | tar -xzC ${SCALA_HOME} --strip-components=1
+
+ENV SBT_VERSION 0.13.8
+
+RUN wget -qO- https://dl.bintray.com/sbt/debian/sbt-${SBT_VERSION}.deb > /tmp/sbt.deb \
+  && dpkg -i /tmp/sbt.deb \
+  && rm -rf /tmp/sbt.deb
+
+ENV SPARK_VERSION 1.3.1
+ENV SPARK_HOME /opt/spark
+ENV SPARK_CONF_DIR ${SPARK_HOME}/conf
+
+RUN mkdir -p ${SPARK_HOME}
+RUN wget -qO- http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop2.6.tgz \
+  | tar -xzC ${SPARK_HOME} --strip-components=1
+
+ENV SPARK_JOBSERVER_VERSION master
+ENV SPARK_JOBSERVER_HOME /opt/spark-jobserver
+
+RUN mkdir -p ${SPARK_JOBSERVER_HOME}
+RUN git clone https://github.com/spark-jobserver/spark-jobserver.git /tmp/spark-jobserver
+
+WORKDIR /tmp/spark-jobserver
+
+RUN sbt ++${SCALA_VERSION} job-server-extras/assembly
+
+RUN cp job-server-extras/target/scala-${SCALA_MAJOR_VERSION}/spark-job-server.jar \
+       job-server/config/log4j-server.properties ${SPARK_JOBSERVER_HOME} \
+  && touch ${SPARK_JOBSERVER_HOME}/settings.sh
+
+COPY etc/spark-jobserver.conf ${SPARK_JOBSERVER_HOME}/spark-jobserver.conf
+COPY etc/log4j.properties ${SPARK_JOBSERVER_HOME}/log4j.properties
+COPY bin/docker-entrypoint.sh ${SPARK_JOBSERVER_HOME}/docker-entrypoint.sh
+
+VOLUME /opt/spark-jobserver/jars
+VOLUME /opt/spark-jobserver/filedao/data
+
+WORKDIR ${SPARK_JOBSERVER_HOME}
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+SCALA_MAJOR_VERSION=2.10
+
+DOCKER_RUN_FLAGS = --detach -p 8090:8090 --name spark-jobserver
+DOCKER_IMAGE_NAME = azavea/spark-jobserver
+
+JOBSERVER_VERSION=0.5.2-SNAPSHOT
+JOBSERVER_FLAGS =
+JOBSERVER_ENDPOINT = http://localhost:8090
+JOBSERVER_TEST_PATH = /tmp/spark-jobserver/job-server-tests/target/scala-$(SCALA_MAJOR_VERSION)
+JOBSERVER_TEST_JAR = job-server-tests_$(SCALA_MAJOR_VERSION)-$(JOBSERVER_VERSION).jar
+JOBSERVER_TEST_CLASS = spark.jobserver.WordCountExample
+
+all: build
+
+build:
+	docker build -t $(DOCKER_IMAGE_NAME) .
+
+clean:
+	docker kill spark-jobserver || true
+	docker rm spark-jobserver || true
+
+test: clean
+	docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE_NAME) $(JOBSERVER_FLAGS)
+	docker exec -ti spark-jobserver /bin/sh -c 'cd /tmp/spark-jobserver && sbt job-server-tests/package'
+	docker exec -ti spark-jobserver curl --silent --data-binary @$(JOBSERVER_TEST_PATH)/$(JOBSERVER_TEST_JAR) \
+		'$(JOBSERVER_ENDPOINT)/jars/test'
+	docker exec -ti spark-jobserver curl --silent --data 'input.string = a b c a b see' \
+		'$(JOBSERVER_ENDPOINT)/jobs?sync=true&appName=test&classPath=$(JOBSERVER_TEST_CLASS)'
+
+.PHONY: all build clean test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# docker-spark-jobserver
+
+[![Docker Repository on Quay.io](https://quay.io/repository/azavea/spark-jobserver/status "Docker Repository on Quay.io")](https://quay.io/repository/azavea/spark-jobserver)
+[![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/azavea/docker-spark-jobserver/blob/develop/LICENSE)
+
+A `Dockerfile` based off of [`java:7`](https://registry.hub.docker.com/_/java/)that an instance of [Spark Job Server](https://github.com/spark-jobserver/spark-jobserver).
+
+## Usage
+
+First, build the container with either of the following commands:
+
+```bash
+$ docker build -t azavea/spark-jobserver .
+```
+
+Or:
+
+```bash
+$ make build
+```
+
+Now you can run the container and provide any custom flags to the `spark-submit` command used to launch the Job Server:
+
+```bash
+$ docker run -ti -p 8090:8090 --name spark-jobserver --driver-memory 2G
+```
+
+## Testing
+
+In order to quickly confirm that things are working, the `test` target of the `Makefile` can be used to chains together the commands (run within the container) required to:
+
+- Build a test job JAR
+- Upload the JAR to the Spark Job Server
+- Execute an the JAR with custom input over HTTP
+
+Below is some example output from running the test:
+
+```
+❯ make test
+docker run --detach -p 8090:8090 --name spark-jobserver azavea/spark-jobserver
+19642d7ee4e308a151ddc75b40e58affee2d010569a48dde05a0cfa1e84dde82
+docker exec -ti spark-jobserver /bin/sh -c 'cd /tmp/spark-jobserver && sbt job-server-tests/package'
+[info] Loading project definition from /tmp/spark-jobserver/project
+[info] Set current project to root (in build file:/tmp/spark-jobserver/)
+[info] scalastyle using config /tmp/spark-jobserver/scalastyle-config.xml
+[info] Processed 5 file(s)
+[info] Found 0 errors
+[info] Found 0 warnings
+[info] Found 0 infos
+[info] Finished in 13 ms
+[success] created output: /tmp/spark-jobserver/job-server-tests/target
+[info] Updating {file:/tmp/spark-jobserver/}job-server-api...
+[info] Resolving org.fusesource.jansi#jansi;1.4 ...
+[info] Done updating.
+[info] Updating {file:/tmp/spark-jobserver/}job-server-tests...
+[info] Resolving org.fusesource.jansi#jansi;1.4 ...
+[info] Done updating.
+[info] scalastyle using config /tmp/spark-jobserver/scalastyle-config.xml
+[info] Processed 3 file(s)
+[info] Found 0 errors
+[info] Found 0 warnings
+[info] Found 0 infos
+[info] Finished in 2 ms
+[success] created output: /tmp/spark-jobserver/job-server-api/target
+[info] Compiling 3 Scala sources to /tmp/spark-jobserver/job-server-api/target/scala-2.10/classes...
+[info] Compiling 5 Scala sources to /tmp/spark-jobserver/job-server-tests/target/scala-2.10/classes...
+[info] Packaging /tmp/spark-jobserver/job-server-tests/target/scala-2.10/job-server-tests_2.10-0.5.2-SNAPSHOT.jar ...
+[info] Done packaging.
+[success] Total time: 36 s, completed Jul 22, 2015 9:29:28 PM
+docker exec -ti spark-jobserver curl --silent --data-binary @/tmp/spark-jobserver/job-server-tests/target/scala-2.10/job-server-tests_2.10-0.5.2-SNAPSHOT.jar \
+                'http://localhost:8090/jars/test'
+OKdocker exec -ti spark-jobserver curl --silent --data 'input.string = a b c a b see' \
+                'http://localhost:8090/jobs?sync=true&appName=test&classPath=spark.jobserver.WordCountExample'
+{
+  "status": "OK",
+  "result": {
+    "a": 2,
+    "b": 2,
+    "see": 1,
+    "c": 1
+  }
+}
+```

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+GC_OPTS="-XX:+UseConcMarkSweepGC -XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled"
+JAVA_OPTS="-XX:MaxDirectMemorySize=512M -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true"
+LOG_OPTS="-Dlog4j.configuration=file:log4j.properties"
+
+exec /opt/spark/bin/spark-submit \
+  --class spark.jobserver.JobServer \
+  --driver-memory 1G \
+  --conf "spark.executor.extraJavaOptions=${LOG_OPTS}" \
+  --driver-java-options "$GC_OPTS $JAVA_OPTS $LOG_OPTS" \
+  "$@" spark-job-server.jar spark-jobserver.conf 2>&1

--- a/etc/log4j.properties
+++ b/etc/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootLogger=INFO,console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Threshold=INFO
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.LOGFILE.layout.ConversionPattern=[%d] %-5p %.26c [%X{testName}] [%X{akkaSource}] - %m%n
+
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=WARN
+log4j.logger.org.apache.spark.scheduler.DAGScheduler=WARN

--- a/etc/spark-jobserver.conf
+++ b/etc/spark-jobserver.conf
@@ -1,0 +1,18 @@
+spark {
+  master = "local[4]"
+
+  job-number-cpus = 4
+
+  jobserver {
+    port = 8090
+    jar-store-rootdir = /opt/spark-jobserver/jars
+
+    jobdao = spark.jobserver.io.JobFileDAO
+
+    filedao {
+      rootdir = /opt/spark-jobserver/filedao/data
+    }
+  }
+
+  home = "/opt/spark"
+}


### PR DESCRIPTION
This is an attempt to produce a Docker container that runs Spark Job Server. It uses the official Java base container provided by Docker and installs:
- Scala
- `sbt`
- Spark
- Spark Job Server

In a later refactor, creating a Spark base container and inheriting from it may be a better approach.

Further instructions around getting things running can be found in the `README`. There is also a mechanism to test the setup in the accompanying `Makefile`.
