### PR TITLE
Move Scala and Spark installation to base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,6 @@
-FROM java:7
+FROM quay.io/azavea/spark:0.1.0
 
 RUN apt-get update && apt-get install -y git --no-install-recommends
-
-ENV SCALA_VERSION 2.10.5
-ENV SCALA_MAJOR_VERSION 2.10
-ENV SCALA_HOME /usr/local/share/scala
-ENV PATH ${PATH}:${SCALA_HOME}/bin
-
-RUN mkdir -p ${SCALA_HOME}
-RUN wget -qO- http://www.scala-lang.org/files/archive/scala-${SCALA_VERSION}.tgz \
-  | tar -xzC ${SCALA_HOME} --strip-components=1
-
-ENV SBT_VERSION 0.13.8
-
-RUN wget -qO- https://dl.bintray.com/sbt/debian/sbt-${SBT_VERSION}.deb > /tmp/sbt.deb \
-  && dpkg -i /tmp/sbt.deb \
-  && rm -rf /tmp/sbt.deb
-
-ENV SPARK_VERSION 1.3.1
-ENV SPARK_HOME /opt/spark
-ENV SPARK_CONF_DIR ${SPARK_HOME}/conf
-
-RUN mkdir -p ${SPARK_HOME}
-RUN wget -qO- http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop2.6.tgz \
-  | tar -xzC ${SPARK_HOME} --strip-components=1
 
 ENV SPARK_JOBSERVER_VERSION master
 ENV SPARK_JOBSERVER_HOME /opt/spark-jobserver

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Docker Repository on Quay.io](https://quay.io/repository/azavea/spark-jobserver/status "Docker Repository on Quay.io")](https://quay.io/repository/azavea/spark-jobserver)
 [![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/azavea/docker-spark-jobserver/blob/develop/LICENSE)
 
-A `Dockerfile` based off of [`java:7`](https://registry.hub.docker.com/_/java/)that an instance of [Spark Job Server](https://github.com/spark-jobserver/spark-jobserver).
+A `Dockerfile` based off of [`azavea/spark`](https://quay.io/repository/azavea/spark) that launches an instance of [Spark Job Server](https://github.com/spark-jobserver/spark-jobserver).
 
 ## Usage
 


### PR DESCRIPTION
Depend on `azavea/scala` and `azavea/spark` to provide the starting point for this container image instead of handling Scala and Spark installations.

Resolves #2 and #3.
