### PR TITLE
Take steps to stabilize container image definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,21 @@
 FROM quay.io/azavea/spark:0.1.0
 
-RUN apt-get update && apt-get install -y git --no-install-recommends
+MAINTAINER Azavea <systems@azavea.com>
 
-ENV SPARK_JOBSERVER_VERSION master
+ENV SPARK_JOBSERVER_VERSION 0.5.2
 ENV SPARK_JOBSERVER_HOME /opt/spark-jobserver
 
-RUN mkdir -p ${SPARK_JOBSERVER_HOME}
-RUN git clone https://github.com/spark-jobserver/spark-jobserver.git /tmp/spark-jobserver
+RUN mkdir -p ${SPARK_JOBSERVER_HOME} ${SPARK_JOBSERVER_BUILD} \
+  && wget -qO ${SPARK_JOBSERVER_HOME}/spark-job-server.jar \
+    https://github.com/azavea/spark-jobserver/releases/download/v${SPARK_JOBSERVER_VERSION}-azavea/spark-job-server.jar
 
-WORKDIR /tmp/spark-jobserver
+WORKDIR ${SPARK_JOBSERVER_HOME}
 
-RUN sbt ++${SCALA_VERSION} job-server-extras/assembly
-
-RUN cp job-server-extras/target/scala-${SCALA_MAJOR_VERSION}/spark-job-server.jar \
-       job-server/config/log4j-server.properties ${SPARK_JOBSERVER_HOME} \
-  && touch ${SPARK_JOBSERVER_HOME}/settings.sh
-
-COPY etc/spark-jobserver.conf ${SPARK_JOBSERVER_HOME}/spark-jobserver.conf
-COPY etc/log4j.properties ${SPARK_JOBSERVER_HOME}/log4j.properties
-COPY bin/docker-entrypoint.sh ${SPARK_JOBSERVER_HOME}/docker-entrypoint.sh
+COPY etc/spark-jobserver.conf ${SPARK_JOBSERVER_HOME}/
+COPY etc/log4j.properties ${SPARK_JOBSERVER_HOME}/
+COPY bin/*.sh ${SPARK_JOBSERVER_HOME}/
 
 VOLUME /opt/spark-jobserver/jars
 VOLUME /opt/spark-jobserver/filedao/data
-
-WORKDIR ${SPARK_JOBSERVER_HOME}
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,7 @@
-SCALA_MAJOR_VERSION=2.10
-
 DOCKER_RUN_FLAGS = --detach -p 8090:8090 --name spark-jobserver
 DOCKER_IMAGE_NAME = azavea/spark-jobserver
 
-JOBSERVER_VERSION=0.5.2-SNAPSHOT
 JOBSERVER_FLAGS =
-JOBSERVER_ENDPOINT = http://localhost:8090
-JOBSERVER_TEST_PATH = /tmp/spark-jobserver/job-server-tests/target/scala-$(SCALA_MAJOR_VERSION)
-JOBSERVER_TEST_JAR = job-server-tests_$(SCALA_MAJOR_VERSION)-$(JOBSERVER_VERSION).jar
-JOBSERVER_TEST_CLASS = spark.jobserver.WordCountExample
 
 all: build
 
@@ -21,10 +14,6 @@ clean:
 
 test: clean
 	docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE_NAME) $(JOBSERVER_FLAGS)
-	docker exec -ti spark-jobserver /bin/sh -c 'cd /tmp/spark-jobserver && sbt job-server-tests/package'
-	docker exec -ti spark-jobserver curl --silent --data-binary @$(JOBSERVER_TEST_PATH)/$(JOBSERVER_TEST_JAR) \
-		'$(JOBSERVER_ENDPOINT)/jars/test'
-	docker exec -ti spark-jobserver curl --silent --data 'input.string = a b c a b see' \
-		'$(JOBSERVER_ENDPOINT)/jobs?sync=true&appName=test&classPath=$(JOBSERVER_TEST_CLASS)'
+	docker exec spark-jobserver /bin/sh -c 'cd /opt/spark-jobserver && ./test.sh'
 
 .PHONY: all build clean test

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+SPARK_JOBSERVER_VERSION="0.5.2"
+
+git clone https://github.com/azavea/spark-jobserver.git /tmp/spark-jobserver
+pushd /tmp/spark-jobserver
+git checkout "v${SPARK_JOBSERVER_VERSION}-azavea"
+
+sbt job-server-tests/package
+
+curl --silent --data-binary @"job-server-tests/target/scala-2.10/job-server-tests_2.10-${SPARK_JOBSERVER_VERSION}.jar" \
+	'http://localhost:8090/jars/test'
+curl --silent --data 'input.string = a b c a b see' \
+	'http://localhost:8090/jobs?sync=true&appName=test&classPath=spark.jobserver.WordCountExample'

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,29 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker login -e . -p ${QUAY_PASSWORD} -u ${QUAY_USER} quay.io
+
+test:
+  pre:
+    - docker build -t quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:${CIRCLE_SHA1:0:7} .
+  override:
+    - docker run -d --name spark-jobserver quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:${CIRCLE_SHA1:0:7}
+    - sudo lxc-attach --keep-env -n "$(docker inspect --format '{{.Id}}' spark-jobserver)" -- /bin/sh -c 'cd /opt/spark-jobserver && ./test.sh'
+
+deployment:
+  latest:
+    branch: master
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:${CIRCLE_SHA1:0:7}
+      - docker tag -f quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:${CIRCLE_SHA1:0:7} quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:latest
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:latest
+
+  release:
+    tag: /[0-9]+(\.[0-9]+)*/
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:$(git tag -l --contains HEAD)
+      - docker tag -f quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:$(git tag -l --contains HEAD) quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:latest
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:latest

--- a/etc/spark-jobserver.conf
+++ b/etc/spark-jobserver.conf
@@ -1,18 +1,18 @@
+###################
+# spark-jobserver #
+###################
+
+spark.jobserver {
+  port = 8090
+  jar-store-rootdir = /opt/spark-jobserver/jars
+  filedao.rootdir = /opt/spark-jobserver/filedao/data
+}
+
+#########
+# spark #
+#########
+
 spark {
-  master = "local[4]"
-
-  job-number-cpus = 4
-
-  jobserver {
-    port = 8090
-    jar-store-rootdir = /opt/spark-jobserver/jars
-
-    jobdao = spark.jobserver.io.JobFileDAO
-
-    filedao {
-      rootdir = /opt/spark-jobserver/filedao/data
-    }
-  }
-
   home = "/opt/spark"
+  master = "local[*]"
 }


### PR DESCRIPTION
Below are a list of changes contained in this pull request that aim at stabilizing the SJS container image definition:
- Pin SJS to the `0.5.2-azavea` release
- Move test procedure into `test.sh`
- Add `MAINTAINER` instruction to `Dockerfile`

Attempts to resolve #5
