### PR TITLE
Upgrade to version 0.6.1; move off Azavea fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-FROM quay.io/azavea/spark:0.1.0
+FROM quay.io/azavea/spark:1.5.2
 
 MAINTAINER Azavea <systems@azavea.com>
 
-ENV SPARK_JOBSERVER_VERSION 0.5.2
+ENV SPARK_JOBSERVER_VERSION 0.6.1
+ENV SPARK_JOBSERVER_SRC_HOME /usr/local/src
 ENV SPARK_JOBSERVER_HOME /opt/spark-jobserver
 
-RUN mkdir -p ${SPARK_JOBSERVER_HOME} ${SPARK_JOBSERVER_BUILD} \
-  && wget -qO ${SPARK_JOBSERVER_HOME}/spark-job-server.jar \
-    https://github.com/azavea/spark-jobserver/releases/download/v${SPARK_JOBSERVER_VERSION}-azavea/spark-job-server.jar
+RUN mkdir -p ${SPARK_JOBSERVER_SRC_HOME} ${SPARK_JOBSERVER_HOME} \
+  && wget -qO- https://github.com/spark-jobserver/spark-jobserver/archive/v${SPARK_JOBSERVER_VERSION}.tar.gz	\
+  | tar -xzC ${SPARK_JOBSERVER_SRC_HOME}
 
-WORKDIR ${SPARK_JOBSERVER_HOME}
+WORKDIR ${SPARK_JOBSERVER_SRC_HOME}/spark-jobserver-${SPARK_JOBSERVER_VERSION}
+
+RUN sbt ++${SCALA_VERSION} job-server-extras/assembly \
+	&& mv job-server-extras/target/scala-2.10/spark-job-server.jar ${SPARK_JOBSERVER_HOME}
 
 COPY etc/spark-jobserver.conf ${SPARK_JOBSERVER_HOME}/
 COPY etc/log4j.properties ${SPARK_JOBSERVER_HOME}/
@@ -17,5 +21,7 @@ COPY bin/*.sh ${SPARK_JOBSERVER_HOME}/
 
 VOLUME /opt/spark-jobserver/jars
 VOLUME /opt/spark-jobserver/filedao/data
+
+WORKDIR ${SPARK_JOBSERVER_HOME}
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER_RUN_FLAGS = --detach -p 8090:8090 --name spark-jobserver
-DOCKER_IMAGE_NAME = azavea/spark-jobserver
+DOCKER_IMAGE_NAME = quay.io/azavea/spark-jobserver:latest
 
 JOBSERVER_FLAGS =
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A `Dockerfile` based off of [`azavea/spark`](https://quay.io/repository/azavea/s
 First, build the container with either of the following commands:
 
 ```bash
-$ docker build -t azavea/spark-jobserver .
+$ docker build -t quay.io/azavea/spark-jobserver:latest .
 ```
 
 Or:

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-SPARK_JOBSERVER_VERSION="0.5.2"
+SPARK_JOBSERVER_VERSION="0.6.1"
 
-git clone https://github.com/azavea/spark-jobserver.git /tmp/spark-jobserver
-pushd /tmp/spark-jobserver
-git checkout "v${SPARK_JOBSERVER_VERSION}-azavea"
+apt-get update && apt-get install -y openjdk-7-jdk
+
+pushd /usr/local/src/spark-jobserver-${SPARK_JOBSERVER_VERSION}
 
 sbt job-server-tests/package
 


### PR DESCRIPTION
In addition to bumping the version of Spark Job Server to 0.6.1, move back to the upstream version of SJS. We were originally on a fork to resolve Joda-Time conflicts.

See also: https://github.com/azavea/spark-jobserver/commits/release/v0.5.2-azavea
